### PR TITLE
Pass timestamp prop (#2)

### DIFF
--- a/modules/timer.js
+++ b/modules/timer.js
@@ -17,7 +17,7 @@ function timer(delay) {
             constructor(props) {
                 super(props);
                 this.delay = delay;
-                this.state = { tick: 0 };
+                this.state = { tick: 0, timestamp: Date.now() };
 
                 this.synchronizeWith = props.synchronizeWith;
                 this.synchronized = props.synchronizeWith !== undefined;
@@ -34,7 +34,10 @@ function timer(delay) {
 
                 this.timer = setTimeout(() => {
                     if (!this.stopped) this.setTimeout();
-                    this.setState({ tick: this.state.tick + 1 });
+                    this.setState({
+                        tick: this.state.tick + 1,
+                        timestamp: Date.now()
+                    });
                 }, duration);
             }
 
@@ -76,9 +79,9 @@ function timer(delay) {
 
             render() {
                 const { props, delay, stop, resume, setDelay } = this;
-                const { tick } = this.state;
+                const { tick, timestamp } = this.state;
 
-                const timer = { delay, tick, stop, resume, setDelay };
+                const timer = { delay, tick, timestamp, stop, resume, setDelay };
 
                 return React.createElement(TimedComponent, { ...props, timer });
             }

--- a/modules/timer.test.js
+++ b/modules/timer.test.js
@@ -32,6 +32,7 @@ describe('Timer', function() {
         counter = findRenderedComponentWithType(wrappedCounter, Counter);
 
         expect(counter.props.timer.tick).to.equal(0);
+        expect(counter.props.timer.timestamp).to.equal(0);
         expect(counter.props.timer.delay).to.equal(1000);
         expect(counter.props.timer.stop).to.be.a.function;
         expect(counter.props.timer.setDelay).to.be.a.function;
@@ -43,6 +44,15 @@ describe('Timer', function() {
         expect(counter.props.timer.tick).to.equal(1);
         clock.tick(1000);
         expect(counter.props.timer.tick).to.equal(2);
+    });
+
+    it('should pass down current timestamp', function() {
+        // Timestamp should already be at 2000ms from previous test.
+        expect(counter.props.timer.timestamp).to.equal(2000);
+        clock.tick(1000);
+        expect(counter.props.timer.timestamp).to.equal(3000);
+        clock.tick(1100);
+        expect(counter.props.timer.timestamp).to.equal(4000);
     });
 
     it('should have the ability to be stopped and resumed', function() {
@@ -58,7 +68,7 @@ describe('Timer', function() {
         expect(wrappedCounter.delay).to.be.equal(60000);
 
         clock.tick(60100);
-        expect(counter.props.timer.tick).to.equal(3);
+        expect(counter.props.timer.tick).to.equal(5);
         expect(counter.props.timer.delay).to.equal(60000);
         counter.props.timer.stop();
     });


### PR DESCRIPTION
Adds a `timestamp` property to the `timer` prop, with supporting tests.

Because the tests build on each other, I had to change an expectation on what is now line 71 as well.

Additionally I ran a local CJS build and tested the update in my project. I did not push the build to GitHub.

This completes the feature described in issue #2.